### PR TITLE
Add toggle button for repeat, encapsulate play order toggle code

### DIFF
--- a/player.html
+++ b/player.html
@@ -38,7 +38,8 @@
 <button id="stop" name="action" title="Stop playback" value="stop"><img alt="Stop" width="24" height="24" src="stock/gtk-media-stop"/></button -->
 <button id="previous-track" name="action" title="Play the previous track" value="prev"><img alt="Previous" width="24" height="24" src="stock/gtk-media-previous-ltr"/></button>
 <button id="next-track" name="action" title="Play the next track" value="next"><img alt="Next Track" width="24" height="24" src="stock/gtk-media-next-ltr"/></button>
-<button id="toggle-shuffle" name="action" title="Toggle Shuffle" value="toggle-shuffle" %(toggle_active)s><img alt="Toggle Shuffle" width="24" height="24" src="stock/media-playlist-shuffle"/></button>
+<button id="toggle-repeat" name="action" title="Toggle Repeat" value="toggle-repeat" %(toggle_repeat_active)s><img alt="Toggle Repeat" width="24" height="24" src="stock/media-playlist-repeat"/></button>
+<button id="toggle-shuffle" name="action" title="Toggle Shuffle" value="toggle-shuffle" %(toggle_shuffle_active)s><img alt="Toggle Shuffle" width="24" height="24" src="stock/media-playlist-shuffle"/></button>
 <button id="volume-up" name="action" title="Turn the volume up" value="vol-up"><img alt="Volume Up" width="24" height="24" src="stock/gtk-go-up"/></button>
 <button id="volume-down" name="action" title="Turn the volume down" value="vol-down"><img alt="Volume Down" width="24" height="24" src="stock/gtk-go-down"/></button>
 </p>

--- a/rhythmweb.js
+++ b/rhythmweb.js
@@ -1,6 +1,7 @@
 function Rhythmweb() {
 	
 	var toggleShuffleEl;
+	var toggleRepeatEl;
 	
 	var reloadWindow = function(data) {
 		// some data has changed on the page
@@ -41,8 +42,16 @@ function Rhythmweb() {
 		toggleShuffleEl.toggleClass('active');
 	};
 	
+	var toggleRepeat = function() {
+		post({'action':'toggle-repeat'});
+		
+		// change active flag
+		toggleRepeatEl.toggleClass('active');
+	};
+	
 	var initialize = function() {
 		toggleShuffleEl = $('#toggle-shuffle');
+		toggleRepeatEl = $('#toggle-repeat');
 		
 		$('#play').click(play);
 		$('#previous-track').click(previousTrack);
@@ -50,6 +59,7 @@ function Rhythmweb() {
 		$('#volume-up').click(volumeUp);
 		$('#volume-down').click(volumeDown);
 		toggleShuffleEl.click(toggleShuffle);
+		toggleRepeatEl.click(toggleRepeat);
 	};
 
 	initialize();

--- a/site.css
+++ b/site.css
@@ -57,6 +57,7 @@ html, body {
 #stop,
 #previous-track,
 #next-track,
+#toggle-repeat,
 #toggle-shuffle {
   float: left;
 }


### PR DESCRIPTION
Added ability to toggle the repeat state of Rhythmbox. The code to toggle repeat is almost identical to that to toggle shuffle, so this was pulled into a common method.
