### PR TITLE
Add support for mobile safari tap and double tap handling

### DIFF
--- a/jquery-mobilesafari-doubletap.js
+++ b/jquery-mobilesafari-doubletap.js
@@ -1,0 +1,45 @@
+/*!
+ * jQuery Double Tap Plugin.
+ *
+ * Copyright (c) 2010 Raul Sanchez (http://www.appcropolis.com)
+ *
+ * Dual licensed under the MIT and GPL licenses:
+ * http://www.opensource.org/licenses/mit-license.php
+ * http://www.gnu.org/licenses/gpl.html
+ */
+ 
+(function($){
+	// Determine if we on iPhone or iPad
+	var isiOS = false;
+	var agent = navigator.userAgent.toLowerCase();
+	if(agent.indexOf('iphone') >= 0 || agent.indexOf('ipad') >= 0){
+		   isiOS = true;
+	}
+ 
+	$.fn.doubletap = function(onDoubleTapCallback, onTapCallback, delay){
+		var eventName, action;
+		delay = delay == null? 500 : delay;
+		eventName = isiOS == true? 'touchend' : 'click';
+ 
+		$(this).bind(eventName, function(event){
+			var now = new Date().getTime();
+			var lastTouch = $(this).data('lastTouch') || now + 1 /** the first time this will make delta a negative number */;
+			var delta = now - lastTouch;
+			clearTimeout(action);
+			if(delta<delay && delta>0){
+				if(onDoubleTapCallback != null && typeof onDoubleTapCallback == 'function'){
+					onDoubleTapCallback(event);
+				}
+			}else{
+				$(this).data('lastTouch', now);
+				action = setTimeout(function(evt){
+					if(onTapCallback != null && typeof onTapCallback == 'function'){
+						onTapCallback(evt);
+					}
+					clearTimeout(action);   // clear the timeout
+				}, delay, [event]);
+			}
+			$(this).data('lastTouch', now);
+		});
+	};
+})(jQuery);

--- a/player.html
+++ b/player.html
@@ -67,5 +67,6 @@
 </div>
 </body>
 <script src="jquery-1.8.1.min.js"></script>
+<script src="jquery-mobilesafari-doubletap.js"></script>
 <script src="rhythmweb.js"/></script>
 </html>

--- a/rhythmweb.js
+++ b/rhythmweb.js
@@ -51,8 +51,23 @@ function Rhythmweb() {
 	
 	var addTrackTableClickHandlers = function() {
 		// add click handlers to all table elements, current and future
-		$('#playlist tr').live('click', handleTrackClicked);
-		$('#playlist tr').live('dblclick', handleTrackDoubleClicked);
+		var agent = navigator.userAgent.toLowerCase();
+		if(agent.indexOf('iphone') >= 0 || agent.indexOf('ipad') >= 0){
+			// register double tap handler, but don't use the single tap handler as it's broken
+			$('#playlist tr').doubletap(
+			    handleTrackDoubleClicked,
+			    null,
+			    300
+			);
+			
+			// install single tap handler
+			$('#playlist tr').live('touchend', handleTrackClicked);
+		}
+		else {
+			// non mobile safari - use standard jquery click handlers
+			$('#playlist tr').live('click', handleTrackClicked);
+			$('#playlist tr').live('dblclick', handleTrackDoubleClicked);
+		}
 	};
 	
 	var handleTrackClicked = function(event) {


### PR DESCRIPTION
Mobile Safari on iPad and iPhone should now work. Needed to install special tap and double tap handlers, using the technique on http://appcropolis.com/implementing-doubletap-on-iphones-and-ipads/ with a quick bug fix.
