### PR TITLE
Android doubletap support integrated into the iOS doubletap plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ cd rhythmweb
 
 Tested Platforms
 ----------------
-
+ - Android 4.2.2 / Google Chrome 27.0.1453.90
  - Ipod/IPad / Safari
  - Mac OS X 10.7.4 / Safari 6.0
  - Mac OS X 10.7.4 / Firefox 14.0.1

--- a/jquery-mobile-doubletap.js
+++ b/jquery-mobile-doubletap.js
@@ -9,17 +9,17 @@
  */
  
 (function($){
-	// Determine if we on iPhone or iPad
-	var isiOS = false;
+	// Determine if we on iPhone or iPad or Android
+	var isiOSAndroid = false;
 	var agent = navigator.userAgent.toLowerCase();
-	if(agent.indexOf('iphone') >= 0 || agent.indexOf('ipad') >= 0){
-		   isiOS = true;
+	if(agent.indexOf('iphone') >= 0 || agent.indexOf('ipad') >= 0 || agent.indexOf('android') >= 0){
+		   isiOSAndroid = true;
 	}
  
 	$.fn.doubletap = function(onDoubleTapCallback, onTapCallback, delay){
 		var eventName, action;
 		delay = delay == null? 500 : delay;
-		eventName = isiOS == true? 'touchend' : 'click';
+		eventName = isiOSAndroid == true? 'touchend' : 'click';
  
 		$(this).bind(eventName, function(event){
 			var now = new Date().getTime();

--- a/player.html
+++ b/player.html
@@ -76,7 +76,7 @@
 </div>
 </body>
 <script src="jquery-1.8.1.min.js"></script>
-<script src="jquery-mobilesafari-doubletap.js"></script>
+<script src="jquery-mobile-doubletap.js"></script>
 <script src="jquery-cookie-1.2.js"></script>
 <script src="rhythmweb.js"/></script>
 </html>

--- a/rhythmweb.js
+++ b/rhythmweb.js
@@ -109,7 +109,7 @@ function Rhythmweb() {
 	var installClickHandlers = function(elementLocator, clickFunction, doubleClickFunction) {
 	    // add click handlers to all table elements, current and future
         var agent = navigator.userAgent.toLowerCase();
-        if(agent.indexOf('iphone') >= 0 || agent.indexOf('ipad') >= 0){
+        if(agent.indexOf('iphone') >= 0 || agent.indexOf('ipad') >= 0 || agent.indexOf('android') >= 0){
             // register double tap handler, but don't use the single tap handler as it's broken
             if(doubleClickFunction != null) {
                 $(elementLocator).doubletap(


### PR DESCRIPTION
The jQuery iOS doubletap plugin can also be used for android so I changed the useragent detection to include android browsers. This is my first contribution on github and had to commit twice because I didn't add the -a switch to the first commit command.
