### PR TITLE
prefs to set port number

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -6,6 +6,9 @@ PLUGIN_PATH="/home/${USER}/.local/share/rhythmbox/plugins/rhythmweb/"
 #build the dirs
 mkdir -p $PLUGIN_PATH
 
+sudo cp org.gnome.rhythmbox.plugins.rhythmweb.gschema.xml /usr/share/glib-2.0/schemas/org.gnome.rhythmbox.plugins.rhythmweb.gschema.xml
+sudo glib-compile-schemas /usr/share/glib-2.0/schemas/
+
 #copy the files
 cp -r "${SCRIPT_PATH}"* "$PLUGIN_PATH"
 

--- a/rhythmweb.py
+++ b/rhythmweb.py
@@ -53,8 +53,8 @@ class RhythmwebPlugin(GObject.GObject, Peas.Activatable):
 
     def __init__(self):
         super(RhythmwebPlugin, self).__init__()
-
-    def do_activate (self):
+ 
+    def do_activate(self): 
         self.shell = self.object
         self.player = self.shell.props.shell_player
         self.db = self.shell.props.db
@@ -68,7 +68,8 @@ class RhythmwebPlugin(GObject.GObject, Peas.Activatable):
             self.db.connect ('entry-extra-metadata-notify',
                              self._extra_metadata_changed_cb)
             ,)
-        self.port = 8000
+        self.prefs = Preferences()
+        self.port = self.prefs.get_port() #8000
         self.server = RhythmwebServer('', self.port, self)
         self._mdns_publish()
 

--- a/rhythmweb_prefs.py
+++ b/rhythmweb_prefs.py
@@ -34,19 +34,39 @@ class Preferences(GObject.Object, PeasGtk.Configurable):
     def __init__(self):
         '''
         Initialises the preferences
-        '''
+        ''' 
+        self.settings = Gio.Settings("org.gnome.rhythmbox.plugins.rhythmweb")
         GObject.Object.__init__(self)
-        
+
+    def btn_apply_clicked(self, widget, instance ):
+        '''
+        Sets the preferences value to the value entered in the text field in the preferences
+        '''
+        try:
+            instance.settings['port'] = int(instance.builder.get_object('textfieldport').get_text())
+            instance.builder.get_object('restartplz').set_visible(True)
+        except:
+            print 'rhythmweb: failed to set port to value from text field'
+
     def do_create_configure_widget(self):
         '''
         Creates the plugin's preferences dialog
         '''
         # create the ui
-        builder = Gtk.Builder()
-        builder.add_from_file(rb.find_plugin_file(self,
-            'ui/rhythmweb_prefs.ui'))
+        self.builder = Gtk.Builder()
+        self.builder.add_from_file(rb.find_plugin_file(self, 'ui/rhythmweb_prefs.ui'))
         #builder.connect_signals(self)
         
+        textinput = self.builder.get_object('textfieldport')
+        textinput.set_text(str(self.settings['port']))
+        self.builder.get_object('restartplz').set_visible(False)
+        self.builder.get_object('buttonapply').connect('clicked', self.btn_apply_clicked, self )
         # return the dialog
-        return builder.get_object('main_notebook')
+        return self.builder.get_object('main_notebook')
+
+    def get_port(self):
+        '''
+        Returns the current port
+        '''
+        return self.settings['port']
 

--- a/ui/rhythmweb_prefs.ui
+++ b/ui/rhythmweb_prefs.ui
@@ -10,23 +10,110 @@
         <property name="can_focus">False</property>
         <property name="orientation">vertical</property>
         <child>
-          <object class="GtkLabel" id="label2">
+          <object class="GtkFrame" id="frame1">
             <property name="visible">True</property>
             <property name="can_focus">False</property>
-            <property name="label">Tested Platforms
-
-    Ipod/IPad / Safari
-    Mac OS X 10.7.4 / Safari 6.0
-    Mac OS X 10.7.4 / Firefox 14.0.1
-    Mac OS X 10.7.4 / Chrome 21.0
-    Win XP SP3 / Firefox 6.0
-    Win XP SP3 / IE 8.0
-    Win XP SP3 / Chrome 21.0: Pass</property>
+            <property name="hexpand">True</property>
+            <property name="label_xalign">0</property>
+            <property name="shadow_type">none</property>
+            <child>
+              <placeholder/>
+            </child>
+            <child type="label_item">
+              <placeholder/>
+            </child>
           </object>
           <packing>
-            <property name="expand">True</property>
+            <property name="expand">False</property>
             <property name="fill">True</property>
             <property name="position">0</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box4">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="vexpand">True</property>
+            <child>
+              <object class="GtkLabel" id="label3">
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="hexpand">True</property>
+                <property name="xpad">10</property>
+                <property name="label" translatable="yes">Port: </property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkEntry" id="textfieldport">
+                <property name="visible">True</property>
+                <property name="can_focus">True</property>
+                <property name="has_default">True</property>
+                <property name="hexpand">True</property>
+                <property name="vexpand">True</property>
+                <property name="max_length">5</property>
+                <property name="invisible_char">•</property>
+                <property name="text" translatable="yes">8000</property>
+                <property name="invisible_char_set">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">True</property>
+                <property name="position">1</property>
+              </packing>
+            </child>
+            <child>
+              <object class="GtkButton" id="buttonapply">
+                <property name="label" translatable="yes">apply</property>
+                <property name="visible">True</property>
+                <property name="can_focus">False</property>
+                <property name="receives_default">True</property>
+                <property name="valign">center</property>
+                <property name="hexpand">True</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">2</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">1</property>
+          </packing>
+        </child>
+        <child>
+          <object class="GtkBox" id="box2">
+            <property name="visible">True</property>
+            <property name="can_focus">False</property>
+            <property name="hexpand">True</property>
+            <property name="vexpand">True</property>
+            <property name="orientation">vertical</property>
+            <child>
+              <object class="GtkLabel" id="restartplz">
+                <property name="can_focus">False</property>
+                <property name="no_show_all">True</property>
+                <property name="vexpand">True</property>
+                <property name="yalign">0.49000000953674316</property>
+                <property name="label" translatable="yes">restart for change to take effect.</property>
+              </object>
+              <packing>
+                <property name="expand">False</property>
+                <property name="fill">False</property>
+                <property name="position">0</property>
+              </packing>
+            </child>
+          </object>
+          <packing>
+            <property name="expand">False</property>
+            <property name="fill">True</property>
+            <property name="position">2</property>
           </packing>
         </child>
       </object>
@@ -42,10 +129,34 @@
       </packing>
     </child>
     <child>
-      <placeholder/>
+      <object class="GtkLabel" id="lblTested">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">Tested Platforms
+
+    Android 4.2.2 / Google Chrome 27.0.1453.90
+    Ipod/IPad / Safari
+    Mac OS X 10.7.4 / Safari 6.0
+    Mac OS X 10.7.4 / Firefox 14.0.1
+    Mac OS X 10.7.4 / Chrome 21.0
+    Win XP SP3 / Firefox 6.0
+    Win XP SP3 / IE 8.0
+    Win XP SP3 / Chrome 21.0: Pass</property>
+      </object>
+      <packing>
+        <property name="position">1</property>
+      </packing>
     </child>
     <child type="tab">
-      <placeholder/>
+      <object class="GtkLabel" id="lblAbout">
+        <property name="visible">True</property>
+        <property name="can_focus">False</property>
+        <property name="label" translatable="yes">About</property>
+      </object>
+      <packing>
+        <property name="position">1</property>
+        <property name="tab_fill">False</property>
+      </packing>
     </child>
     <child>
       <placeholder/>


### PR DESCRIPTION
I had a fun afternoon learning some python. 

I just noticed, in file: rhythmweb_prefs.py line 62 is redundant because the item is already set invisible in Glade self.builder.get_object('restartplz').set_visible(False) 
